### PR TITLE
nix: Remove `hsPkgs` from flake packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,6 @@
     # nix build
     packages = forAllSystems (
       {hsPkgs, ...}: {
-        inherit hsPkgs;
         htmx = hsPkgs.htmx;
         default = hsPkgs.htmx;
       }


### PR DESCRIPTION
Because, it is not really a derivation:

```
❯ nix build github:JonathanLorimer/htmx#hsPkgs
error: expected flake output attribute 'packages.x86_64-linux.hsPkgs' to be a derivation or path but found a set: { "2captcha" = «thunk»; "3d-graphics-examples" = «thunk»; "3dmodels" = «thunk»; "4Blocks" = «thunk»; AAI = «thunk»; ABList = «thunk»; AC-Angle = «thunk»; AC-Boolean = «thunk»; AC-BuildPlatform = «thunk»; AC-Colour = «thunk»; «18180 attributes elided» }
```